### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,5 +36,6 @@ setup(name='ansible-nsxt-modules',
         'License :: OSI Approved :: BSD License',
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)'
         'Programming Language :: Python',
-      ]
+      ],
+      py_modules=[]
       )


### PR DESCRIPTION
workaround for failure while building sap.nsxt image. 
Failure was
----------------------------------------------------------------------------
error: subprocess-exited-with-error
#25 204.7   
#25 204.7   × Running setup.py install for ansible-nsxt-modules did not run successfully.
#25 204.7   │ exit code: 1
#25 204.7   ╰─> [14 lines of output]
#25 204.7       error: Multiple top-level packages discovered in a flat-layout: ['library', 'module_utils'].
#25 204.7       
#25 204.7       To avoid accidental inclusion of unwanted files or directories,
#25 204.7       setuptools will not proceed with this build.
#25 204.7       
#25 204.7       If you are trying to create a single distribution with multiple packages
#25 204.7       on purpose, you should not rely on automatic discovery.
#25 204.7       Instead, consider the following options:
#25 204.7       
#25 204.7       1. set up custom discovery (`find` directive with `include` or `exclude`)
#25 204.7       2. use a `src-layout`
#25 204.7       3. explicitly set `py_modules` or `packages` with a list of names
#25 204.7       
#25 204.7       To find more information, look for "package discovery" on setuptools docs.
#25 204.7       [end of output]